### PR TITLE
Only copy platform node_modules when created by binary

### DIFF
--- a/src/bin/create
+++ b/src/bin/create
@@ -69,6 +69,7 @@ else {
         cli: argv.cli,
         link: argv.link || argv.shared,
         customTemplate: argv.argv.remain[3],
+        copyPlatformNodeModules: true
     };
 
     Api.createPlatform(projectPath, config, options);


### PR DESCRIPTION
### Platforms affected
test-platform

### What does this PR do?
When platform is installed though CLI, `cordova platform add ...`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

Since this is the test-platform and used as a base for new platforms, this PR only adds the flag to the create binary. The test platform does not contain any of the create logic to copy files including platform node_modules.

### What testing has been done on this change?
- npm t