### PR TITLE
Dependency bump cordova-common@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   ],
   "dependencies": {
-    "cordova-common": "^2.0.1",
+    "cordova-common": "^3.0.0",
     "nopt": "^4.0.1",
     "shelljs": "^0.3.0"
   },


### PR DESCRIPTION
### Platforms affected
test platform

### What does this PR do?
Updates the cordova-common dependency to ^3.0.0.

### What testing has been done on this change?
- `npm t`